### PR TITLE
style: set white background for distribution dataframe

### DIFF
--- a/app.py
+++ b/app.py
@@ -367,7 +367,11 @@ if not metrics_df.empty:
             )
             st.altair_chart(chart, use_container_width=True)
         with cc2:
-            st.dataframe(dist_df, use_container_width=True, hide_index=True)
+            st.dataframe(
+                dist_df.style.set_properties(**{"background-color": "#ffffff"}),
+                use_container_width=True,
+                hide_index=True,
+            )
 else:
     st.caption("Pas de métriques globales disponibles pour dessiner la distribution.")
 


### PR DESCRIPTION
## Summary
- ensure keyword distribution dataframe uses a white background

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af4c3281948329872ae91cf92b2f37