### PR TITLE
feat: update secondary background color

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -3,7 +3,7 @@
 base = "light"                     # force le mode clair (pas "System")
 primaryColor = "#0B8A65"
 backgroundColor = "#F7F4EB"        # fond page
-secondaryBackgroundColor = "#F7F4EB" # fond sidebar/cartes
+secondaryBackgroundColor = "#FFFFFF" # fond sidebar/cartes
 textColor = "#111111"
 font = "sans serif"
 


### PR DESCRIPTION
## Summary
- set Streamlit secondary background color to white

## Testing
- `pytest`
- `streamlit run app.py`

------
https://chatgpt.com/codex/tasks/task_e_68af500e31688329b8df5b295662d383