### PR TITLE
Initialize request before safe_post and guard error

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,13 +53,14 @@ def _auth_headers(login: str, password: str) -> dict:
     return {"Authorization": f"Basic {tok}", "Content-Type": "application/json"}
 
 def safe_post(url: str, headers: dict, payload: list, timeout: int = 90) -> dict:
+    r = None
     try:
         r = requests.post(url, headers=headers, data=json.dumps(payload), timeout=timeout)
         r.raise_for_status()
         return r.json()
     except Exception as e:
         try:
-            err = r.json()
+            err = r.json() if r is not None else str(e)
         except Exception:
             err = str(e)
         st.error(f"API error on {url}: {err}")


### PR DESCRIPTION
## Summary
- Prevent unbound variable by initializing request variable before POST
- Safely handle missing response during error reporting

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b002c4d654832989a4cb2ff38a014a