### PR TITLE
feat: import Screaming Frog categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ pinned: false
 ---
 
 Check out the configuration reference at https://huggingface.co/docs/hub/spaces-config-reference
+
+## Screaming Frog export
+
+The app accepts a Screaming Frog "Internal: All" export as CSV or Excel. The file must contain an `Address` column with the full URL of each crawled page. The first folder or parameter of the URL is used to guess an initial category, which can then be edited in the interface before generating default regex rules for Google Search Console.


### PR DESCRIPTION
## Summary
- allow uploading Screaming Frog export to derive URL categories
- let users edit mapping and generate regex rules for GSC
- document expected Screaming Frog export format

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0070056448329a0b80b81ed1144d5