### PR TITLE
Add Google Search Console metrics and categorization

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from datetime import date, timedelta
 import pandas as pd
 import requests
 import streamlit as st
+from gsc import query_search_console
 
 API_BASE = "https://api.dataforseo.com/v3"
 
@@ -442,6 +443,52 @@ else:
     # ========================= CONCURRENCE =========================
 st.divider()
 st.subheader("Competition analysis")
+
+# ---------- Google Search Console ----------
+site_url = f"https://{target_domain}/"
+gsc_dates = query_search_console(
+    site_url,
+    start_A.strftime("%Y-%m-%d"),
+    end_d.strftime("%Y-%m-%d"),
+    dimensions=["date"],
+)
+if not gsc_dates.empty:
+    st.line_chart(gsc_dates.set_index("date")[["clicks", "impressions", "ctr", "position"]])
+else:
+    st.info("Aucune donnée Search Console pour cette période.")
+
+gsc_pages = query_search_console(
+    site_url,
+    start_A.strftime("%Y-%m-%d"),
+    end_d.strftime("%Y-%m-%d"),
+    dimensions=["page"],
+)
+if not gsc_pages.empty:
+    st.caption("Regex → catégorie (format: `regex -> catégorie`)")
+    cat_text = st.text_area(" ", height=120, key="regex_map")
+    patterns = []
+    for line in cat_text.splitlines():
+        if "->" in line:
+            rgx, cat = map(str.strip, line.split("->", 1))
+            if rgx and cat:
+                try:
+                    patterns.append((re.compile(rgx), cat))
+                except re.error:
+                    pass
+    if patterns:
+        gsc_pages["category"] = "Autres"
+        for rgx, cat in patterns:
+            gsc_pages.loc[gsc_pages["page"].str.contains(rgx), "category"] = cat
+        agg = (
+            gsc_pages.groupby("category")
+            .agg({"clicks": "sum", "impressions": "sum", "position": "mean"})
+            .reset_index()
+        )
+        agg["ctr"] = (agg["clicks"] / agg["impressions"]).fillna(0)
+        agg = agg[["category", "clicks", "impressions", "ctr", "position"]]
+        st.dataframe(agg.round(2))
+        st.bar_chart(agg.set_index("category")[["clicks", "impressions"]])
+
 
 # ---------- 1) UI : labels + sélection de concurrents ----------
 # options de labels/thèmes (comme pour le radar)

--- a/gsc.py
+++ b/gsc.py
@@ -1,0 +1,78 @@
+import os
+import json
+from typing import List
+
+import pandas as pd
+import streamlit as st
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+
+SCOPES = ["https://www.googleapis.com/auth/webmasters.readonly"]
+
+@st.cache_data(show_spinner=False)
+def _get_service():
+    """Authenticate and return a Search Console service."""
+    info = os.getenv("GSC_SERVICE_ACCOUNT_JSON", "")
+    key_dict = None
+    if info:
+        try:
+            key_dict = json.loads(info)
+        except Exception:
+            key_dict = None
+    if key_dict is None:
+        try:
+            key_dict = dict(st.secrets.get("gsc_service_account", {}))
+        except Exception:
+            key_dict = None
+    if not key_dict:
+        return None
+    creds = service_account.Credentials.from_service_account_info(key_dict, scopes=SCOPES)
+    return build("searchconsole", "v1", credentials=creds, cache_discovery=False)
+
+@st.cache_data(show_spinner=True)
+def query_search_console(site_url: str, start_date: str, end_date: str,
+                         dimensions: List[str] | None = None, row_limit: int = 25000) -> pd.DataFrame:
+    """Run a searchanalytics.query and return a DataFrame."""
+    service = _get_service()
+    if service is None:
+        return pd.DataFrame()
+    dimensions = dimensions or ["date"]
+    rows, start_row = [], 0
+    while start_row < row_limit:
+        body = {
+            "startDate": start_date,
+            "endDate": end_date,
+            "dimensions": dimensions,
+            "rowLimit": min(25000, row_limit - start_row),
+            "startRow": start_row,
+        }
+        if body["rowLimit"] <= 0:
+            break
+        try:
+            resp = service.searchanalytics().query(siteUrl=site_url, body=body).execute()
+        except Exception:
+            break
+        rws = resp.get("rows", [])
+        if not rws:
+            break
+        rows.extend(rws)
+        start_row += len(rws)
+        if len(rws) < body["rowLimit"]:
+            break
+    if not rows:
+        cols = dimensions + ["clicks", "impressions", "ctr", "position"]
+        return pd.DataFrame(columns=cols)
+    records = []
+    for r in rows:
+        rec = {d: k for d, k in zip(dimensions, r.get("keys", []))}
+        rec.update({
+            "clicks": r.get("clicks", 0),
+            "impressions": r.get("impressions", 0),
+            "ctr": r.get("ctr", 0),
+            "position": r.get("position", 0),
+        })
+        records.append(rec)
+    df = pd.DataFrame(records)
+    if "date" in df.columns:
+        df["date"] = pd.to_datetime(df["date"])
+    return df

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ streamlit>=1.36
 plotly>=5.22
 streamlit-aggrid>=0.3.5
 altair
+google-api-python-client>=2.122.0


### PR DESCRIPTION
## Summary
- add `gsc.py` module using service account auth to query Search Console
- display time-series clicks/impressions/ctr/position in Competition analysis
- allow regex-to-category mapping to aggregate URL metrics by category
- add Google API client dependency

## Testing
- `python -m py_compile gsc.py app.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement google-api-python-client>=2.122.0)*


------
https://chatgpt.com/codex/tasks/task_e_68b006fb984c832997b18009ca3cac40